### PR TITLE
Switch to CommunityToolkit.Mvvm/Microsoft.Extensions.DependencyInjection

### DIFF
--- a/DevServer.Services/EntryService.cs
+++ b/DevServer.Services/EntryService.cs
@@ -82,9 +82,9 @@ public class EntryService : IEntryService
         return new MemoryStream(bytes);
     }
 
-    internal async Task<Stream> GetLogoStreamFromLocalFile(string path)
+    internal Task<Stream> GetLogoStreamFromLocalFile(string path)
     {
-        var stream = await Task.Run(() => _fileSystem.File.OpenRead(path));
-        return stream;
+        var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
+        return Task.FromResult<Stream>(stream);
     }
 }

--- a/DevServer/App.axaml
+++ b/DevServer/App.axaml
@@ -1,11 +1,6 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="using:DevServer"
              x:Class="DevServer.App">
-    <Application.DataTemplates>
-        <local:ViewLocator />
-    </Application.DataTemplates>
-
     <Application.Styles>
         <FluentTheme Mode="Light" />
         <StyleInclude Source="avares://Material.Icons.Avalonia/App.xaml" />

--- a/DevServer/App.axaml.cs
+++ b/DevServer/App.axaml.cs
@@ -16,6 +16,7 @@ using HanumanInstitute.MvvmDialogs;
 using HanumanInstitute.MvvmDialogs.Avalonia;
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 using HttpClientHandler = DevServer.Services.HttpClientHandler;
 
@@ -79,6 +80,7 @@ public class App : Application
     {
         var services = new ServiceCollection();
 
+        services.AddLogging(logging => logging.AddConsole());
         services.AddSingleton<IPlatformService>(new PlatformService("devserver"));
         services.AddSingleton<IHttpHandler>(new HttpClientHandler(new HttpClient()));
         services.AddSingleton<ViewLocator>();
@@ -98,7 +100,9 @@ public class App : Application
                                                  provider.GetRequiredService<IFileSystem>(),
                                                  provider.GetRequiredService<IHttpHandler>()));
 
-        services.AddSingleton(provider => new EntryListViewModel(provider.GetRequiredService<IEntryService>()));
+        services.AddSingleton(provider => new EntryListViewModel(
+                                  provider.GetRequiredService<ILogger<EntryListViewModel>>(),
+                                  provider.GetRequiredService<IEntryService>()));
         services.AddSingleton(provider => new MainWindowViewModel(provider.GetRequiredService<EntryListViewModel>()));
 
         return services.BuildServiceProvider();

--- a/DevServer/DesignData.cs
+++ b/DevServer/DesignData.cs
@@ -5,7 +5,7 @@ namespace DevServer;
 
 public static class DesignData
 {
-    public static MainWindowViewModel MainWindowViewModel => new();
+    public static MainWindowViewModel MainWindowViewModel => new(EntryListViewModel);
 
     public static EntryListViewModel EntryListViewModel => new(null!);
 

--- a/DevServer/DesignData.cs
+++ b/DevServer/DesignData.cs
@@ -7,7 +7,7 @@ public static class DesignData
 {
     public static MainWindowViewModel MainWindowViewModel => new(EntryListViewModel);
 
-    public static EntryListViewModel EntryListViewModel => new(null!);
+    public static EntryListViewModel EntryListViewModel => new(null!, null!);
 
     public static EntryViewModel EntryViewModel { get; } =
         new(new Entry

--- a/DevServer/DevServer.csproj
+++ b/DevServer/DevServer.csproj
@@ -23,14 +23,12 @@
     <PackageReference Include="Avalonia.Desktop" Version="0.10.18" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.18" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.18" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
     <PackageReference Include="HanumanInstitute.MvvmDialogs.Avalonia" Version="1.3.1" />
     <PackageReference Include="HanumanInstitute.MvvmDialogs.Avalonia.MessageBox" Version="1.3.1" />
     <PackageReference Include="Material.Icons.Avalonia" Version="1.1.10" />
-    <PackageReference Include="Splat.DependencyInjection.SourceGenerator" Version="1.1.69">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
   </ItemGroup>
   <ItemGroup>

--- a/DevServer/DevServer.csproj
+++ b/DevServer/DevServer.csproj
@@ -30,6 +30,8 @@
     <PackageReference Include="Material.Icons.Avalonia" Version="1.1.10" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
   </ItemGroup>
   <ItemGroup>

--- a/DevServer/DevServer.csproj
+++ b/DevServer/DevServer.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Avalonia.Desktop" Version="0.10.18" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.18" />
+    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="0.10.18" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
     <PackageReference Include="HanumanInstitute.MvvmDialogs.Avalonia" Version="1.3.1" />
     <PackageReference Include="HanumanInstitute.MvvmDialogs.Avalonia.MessageBox" Version="1.3.1" />

--- a/DevServer/Program.cs
+++ b/DevServer/Program.cs
@@ -2,6 +2,10 @@
 using System.Threading;
 
 using Avalonia;
+using Avalonia.Controls;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace DevServer;
 
@@ -23,6 +27,12 @@ internal class Program
 
             BuildAvaloniaApp()
                 .StartWithClassicDesktopLifetime(args);
+        }
+        catch (Exception e)
+        {
+            var services = (IServiceProvider)Application.Current!.FindResource(typeof(IServiceProvider))!;
+            var logger = services.GetRequiredService<ILogger<Program>>();
+            logger.LogError(e, "Unexpected exception");
         }
         finally
         {

--- a/DevServer/Program.cs
+++ b/DevServer/Program.cs
@@ -1,20 +1,7 @@
 ﻿using System;
-using System.IO.Abstractions;
-using System.Net.Http;
 using System.Threading;
 
 using Avalonia;
-using Avalonia.ReactiveUI;
-
-using DevServer.Services;
-using DevServer.ViewModels;
-
-using HanumanInstitute.MvvmDialogs;
-using HanumanInstitute.MvvmDialogs.Avalonia;
-
-using Splat;
-
-using HttpClientHandler = DevServer.Services.HttpClientHandler;
 
 namespace DevServer;
 
@@ -34,9 +21,6 @@ internal class Program
                 return;
             }
 
-            SplatRegistrations.SetupIOC();
-            RegisterDependencies();
-
             BuildAvaloniaApp()
                 .StartWithClassicDesktopLifetime(args);
         }
@@ -46,38 +30,10 @@ internal class Program
         }
     }
 
-    public static void RegisterDependencies()
-    {
-        var mutableResolver = Locator.CurrentMutable;
-        var readonlyResolver = Locator.Current;
-
-        mutableResolver.RegisterLazySingleton<IPlatformService>(() => new PlatformService("devserver"));
-        mutableResolver.RegisterLazySingleton<IHttpHandler>(
-            () => new HttpClientHandler(new HttpClient()));
-
-        mutableResolver.RegisterLazySingleton<IDialogService>(
-            () => new DialogService(
-                new DialogManager(new ViewLocator(),
-                                  new DialogFactory().AddMessageBox()),
-                viewModelFactory: x => readonlyResolver.GetService(x)));
-
-        SplatRegistrations.RegisterLazySingleton<IProcess, ProcessProxy>();
-        SplatRegistrations.RegisterLazySingleton<INativeRunner, NativeRunner>();
-        SplatRegistrations.RegisterLazySingleton<IWineRunner, WineRunner>();
-        SplatRegistrations.RegisterLazySingleton<IFileSystem, FileSystem>();
-        SplatRegistrations.RegisterLazySingleton<IConfigurationManager, ConfigurationManager>();
-        SplatRegistrations.RegisterLazySingleton<IHttpHandler, HttpClientHandler>();
-        SplatRegistrations.RegisterLazySingleton<IEntryService, EntryService>();
-
-        SplatRegistrations.RegisterLazySingleton<EntryListViewModel>();
-        SplatRegistrations.RegisterLazySingleton<MainWindowViewModel>();
-    }
-
     public static AppBuilder BuildAvaloniaApp()
     {
         return AppBuilder.Configure<App>()
                          .UsePlatformDetect()
-                         .LogToTrace()
-                         .UseReactiveUI();
+                         .LogToTrace();
     }
 }

--- a/DevServer/ViewLocator.cs
+++ b/DevServer/ViewLocator.cs
@@ -1,11 +1,50 @@
+using System;
+using System.Reflection;
+
+using Avalonia.Controls;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+using HanumanInstitute.MvvmDialogs;
 using HanumanInstitute.MvvmDialogs.Avalonia;
+
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DevServer;
 
 public class ViewLocator : ViewLocatorBase
 {
+    private readonly IServiceProvider _serviceProvider;
+
+    public ViewLocator(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
     protected override string GetViewName(object viewModel)
     {
         return viewModel.GetType().FullName!.Replace("ViewModel", "");
+    }
+
+    public override object Locate(object viewModel)
+    {
+        var viewName = GetViewName(viewModel);
+        var type = Assembly.GetEntryAssembly()?.GetType(viewName);
+        var obj = type != null ? _serviceProvider.GetRequiredService(type) : null;
+
+        switch (obj)
+        {
+            case Window _:
+            case IControl _:
+            case IWindow _:
+                return obj;
+            default:
+                throw new TypeLoadException($"Dialog {viewName} is missing");
+        }
+    }
+
+    public override bool Match(object data)
+    {
+        return data is ObservableObject;
     }
 }

--- a/DevServer/ViewLocator.cs
+++ b/DevServer/ViewLocator.cs
@@ -32,15 +32,11 @@ public class ViewLocator : ViewLocatorBase
         var type = Assembly.GetEntryAssembly()?.GetType(viewName);
         var obj = type != null ? _serviceProvider.GetRequiredService(type) : null;
 
-        switch (obj)
+        return obj switch
         {
-            case Window _:
-            case IControl _:
-            case IWindow _:
-                return obj;
-            default:
-                throw new TypeLoadException($"Dialog {viewName} is missing");
-        }
+             Window or IWindow or IControl => obj,
+            _ => throw new TypeLoadException($"Dialog {viewName} is missing")
+        };
     }
 
     public override bool Match(object data)

--- a/DevServer/ViewModels/EntryListViewModel.cs
+++ b/DevServer/ViewModels/EntryListViewModel.cs
@@ -1,53 +1,31 @@
-using System.Reactive;
 using System.Threading.Tasks;
 
 using Avalonia.Collections;
 
-using DevServer.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 
-using ReactiveUI;
+using DevServer.Services;
 
 namespace DevServer.ViewModels;
 
-public class EntryListViewModel : ViewModelBase
+public partial class EntryListViewModel : ViewModelBase
 {
     private readonly IEntryService _entryService;
 
-    private AvaloniaList<EntryViewModel> _entries = new();
-    private EntryViewModel? _selectedEntry;
+    [ObservableProperty] private AvaloniaList<EntryViewModel> _entries = new();
 
-    public AvaloniaList<EntryViewModel> Entries
-    {
-        get => _entries;
-        set => this.RaiseAndSetIfChanged(ref _entries, value);
-    }
-
-    public EntryViewModel? SelectedEntry
-    {
-        get => _selectedEntry;
-        set => this.RaiseAndSetIfChanged(ref _selectedEntry, value);
-    }
-
-    public ReactiveCommand<Unit, Unit> UpdateEntriesCommand { get; }
-    public ReactiveCommand<Unit, Unit> DirectConnectCommand { get; }
-    public ReactiveCommand<Unit, Unit> AddEntryCommand { get; }
-    public ReactiveCommand<Unit, Unit> EditEntryCommand { get; }
-    public ReactiveCommand<Unit, Unit> DeleteEntryCommand { get; }
+    [ObservableProperty] private EntryViewModel? _selectedEntry;
 
     public EntryListViewModel(IEntryService entryService)
     {
         _entryService = entryService;
 
-        UpdateEntriesCommand = ReactiveCommand.CreateFromTask(UpdateEntries);
-        DirectConnectCommand = ReactiveCommand.CreateFromTask(DirectConnect);
-        AddEntryCommand = ReactiveCommand.CreateFromTask(AddEntry);
-        EditEntryCommand = ReactiveCommand.CreateFromTask(EditEntry);
-        DeleteEntryCommand = ReactiveCommand.CreateFromTask(DeleteEntry);
-
-        UpdateEntriesCommand.Execute();
+        UpdateEntriesCommand.ExecuteAsync(null);
     }
 
 
+    [RelayCommand]
     private async Task UpdateEntries()
     {
         Entries.Clear();
@@ -58,21 +36,25 @@ public class EntryListViewModel : ViewModelBase
         }
     }
 
+    [RelayCommand]
     private Task DirectConnect()
     {
         return Task.CompletedTask;
     }
 
+    [RelayCommand]
     private Task AddEntry()
     {
         return Task.CompletedTask;
     }
 
+    [RelayCommand]
     private Task EditEntry()
     {
         return Task.CompletedTask;
     }
 
+    [RelayCommand]
     private async Task DeleteEntry()
     {
         if (_selectedEntry is null)

--- a/DevServer/ViewModels/EntryListViewModel.cs
+++ b/DevServer/ViewModels/EntryListViewModel.cs
@@ -20,8 +20,6 @@ public partial class EntryListViewModel : ViewModelBase
     public EntryListViewModel(IEntryService entryService)
     {
         _entryService = entryService;
-
-        UpdateEntriesCommand.ExecuteAsync(null);
     }
 
 

--- a/DevServer/ViewModels/EntryListViewModel.cs
+++ b/DevServer/ViewModels/EntryListViewModel.cs
@@ -13,9 +13,11 @@ public partial class EntryListViewModel : ViewModelBase
 {
     private readonly IEntryService _entryService;
 
-    [ObservableProperty] private AvaloniaList<EntryViewModel> _entries = new();
+    [ObservableProperty]
+    private AvaloniaList<EntryViewModel> _entries = new();
 
-    [ObservableProperty] private EntryViewModel? _selectedEntry;
+    [ObservableProperty]
+    private EntryViewModel? _selectedEntry;
 
     public EntryListViewModel(IEntryService entryService)
     {

--- a/DevServer/ViewModels/EntryViewModel.cs
+++ b/DevServer/ViewModels/EntryViewModel.cs
@@ -33,8 +33,6 @@ public partial class EntryViewModel : ViewModelBase
         _configurationManager = Services.GetRequiredService<IConfigurationManager>();
         _nativeRunner = Services.GetRequiredService<INativeRunner>();
         _wineRunner = Services.GetRequiredService<IWineRunner>();
-
-        LoadLogoCommand.ExecuteAsync(null);
     }
 
     [RelayCommand]

--- a/DevServer/ViewModels/EntryViewModel.cs
+++ b/DevServer/ViewModels/EntryViewModel.cs
@@ -20,7 +20,8 @@ public partial class EntryViewModel : ViewModelBase
     private readonly INativeRunner _nativeRunner;
     private readonly IWineRunner _wineRunner;
 
-    [ObservableProperty] private Bitmap? _logo;
+    [ObservableProperty]
+    private Bitmap? _logo;
 
     public string FilePath => _entry.FilePath;
     public string Name => _entry.Name;

--- a/DevServer/ViewModels/MainWindowViewModel.cs
+++ b/DevServer/ViewModels/MainWindowViewModel.cs
@@ -1,9 +1,11 @@
-﻿using Splat;
-
-namespace DevServer.ViewModels;
+﻿namespace DevServer.ViewModels;
 
 public class MainWindowViewModel : ViewModelBase
 {
-    [DependencyInjectionProperty]
-    public EntryListViewModel EntryListViewModel { get; set; }
+    public EntryListViewModel EntryListViewModel { get; }
+
+    public MainWindowViewModel(EntryListViewModel entryListViewModel)
+    {
+        EntryListViewModel = entryListViewModel;
+    }
 }

--- a/DevServer/ViewModels/ViewModelBase.cs
+++ b/DevServer/ViewModels/ViewModelBase.cs
@@ -1,7 +1,14 @@
-﻿using ReactiveUI;
+﻿using System;
+
+using Avalonia;
+using Avalonia.Controls;
+
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace DevServer.ViewModels;
 
-public class ViewModelBase : ReactiveObject
+public class ViewModelBase : ObservableObject
 {
+    protected static IServiceProvider Services =>
+        (IServiceProvider)Application.Current!.FindResource(typeof(IServiceProvider))!;
 }

--- a/DevServer/Views/EntryListView.axaml
+++ b/DevServer/Views/EntryListView.axaml
@@ -5,9 +5,17 @@
              xmlns:material="using:Material.Icons.Avalonia"
              xmlns:local="clr-namespace:DevServer"
              xmlns:views="clr-namespace:DevServer.Views"
+             xmlns:i="using:Avalonia.Xaml.Interactivity"
+             xmlns:ia="using:Avalonia.Xaml.Interactions.Core"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="DevServer.Views.EntryListView"
              d:DataContext="{x:Static local:DesignData.EntryListViewModel}">
+
+    <i:Interaction.Behaviors>
+        <ia:EventTriggerBehavior EventName="AttachedToVisualTree">
+            <ia:InvokeCommandAction Command="{Binding UpdateEntriesCommand}" />
+        </ia:EventTriggerBehavior>
+    </i:Interaction.Behaviors>
 
     <Grid RowDefinitions="* Auto">
         <ListBox Items="{Binding Entries}"

--- a/DevServer/Views/EntryView.axaml
+++ b/DevServer/Views/EntryView.axaml
@@ -4,9 +4,17 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:material="using:Material.Icons.Avalonia"
              xmlns:local="clr-namespace:DevServer"
+             xmlns:i="using:Avalonia.Xaml.Interactivity"
+             xmlns:ia="using:Avalonia.Xaml.Interactions.Core"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="100"
              x:Class="DevServer.Views.EntryView"
              d:DataContext="{x:Static local:DesignData.EntryViewModel}">
+
+    <i:Interaction.Behaviors>
+        <ia:EventTriggerBehavior EventName="AttachedToVisualTree">
+            <ia:InvokeCommandAction Command="{Binding LoadLogoCommand}" />
+        </ia:EventTriggerBehavior>
+    </i:Interaction.Behaviors>
 
     <Grid ColumnDefinitions="Auto * Auto">
         <DockPanel Grid.Column="0" Margin="0 0 10 0">


### PR DESCRIPTION
For a small project like this, ReactiveUI seems unnecessarily finicky to be used, thus CommunityToolkit.Mvvm/Microsoft.Extensions.DependencyInjection stack has been chosen to go with. Exceptions are also now properly handled and logged. UpdateEntries and LoadLogo are now invoked on AttachedToVisualTree event instead of the constructor. GetLogoStreamFromLocalFile returns an async FileStream.