### PR TITLE
Entry manipulation in EntryView / Separate button panel from EntryListView

### DIFF
--- a/DevServer/App.axaml.cs
+++ b/DevServer/App.axaml.cs
@@ -111,10 +111,12 @@ public class App : Application
                                                  provider.GetRequiredService<IFileSystem>(),
                                                  provider.GetRequiredService<IHttpHandler>()));
 
-        services.AddSingleton(provider => new EntryListViewModel(
-                                  provider.GetRequiredService<ILogger<EntryListViewModel>>(),
+        services.AddSingleton(provider => new MainPanelViewModel(
+                                  provider.GetRequiredService<ILogger<MainPanelViewModel>>(),
                                   provider.GetRequiredService<IEntryService>()));
-        services.AddSingleton(provider => new MainWindowViewModel(provider.GetRequiredService<EntryListViewModel>()));
+        services.AddSingleton(provider => new EntryListViewModel());
+        services.AddSingleton(provider => new MainWindowViewModel(provider.GetRequiredService<EntryListViewModel>(),
+                                                                  provider.GetRequiredService<MainPanelViewModel>()));
 
         return services.BuildServiceProvider();
     }

--- a/DevServer/DesignData.cs
+++ b/DevServer/DesignData.cs
@@ -5,9 +5,11 @@ namespace DevServer;
 
 public static class DesignData
 {
-    public static MainWindowViewModel MainWindowViewModel => new(EntryListViewModel);
+    public static MainWindowViewModel MainWindowViewModel => new(EntryListViewModel, MainPanelViewModel);
 
-    public static EntryListViewModel EntryListViewModel => new(null!, null!);
+    public static EntryListViewModel EntryListViewModel => new();
+
+    public static MainPanelViewModel MainPanelViewModel => new(null!, null!);
 
     public static EntryViewModel EntryViewModel { get; } =
         new(new Entry

--- a/DevServer/Messages/EntriesChangedMessaged.cs
+++ b/DevServer/Messages/EntriesChangedMessaged.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+using CommunityToolkit.Mvvm.Messaging.Messages;
+
+using DevServer.ViewModels;
+
+namespace DevServer.Messages;
+
+public class EntriesChangedMessage : ValueChangedMessage<IList<EntryViewModel>>
+{
+    public EntriesChangedMessage(IList<EntryViewModel> value) : base(value)
+    {
+    }
+}

--- a/DevServer/Messages/EntriesRequestMessage.cs
+++ b/DevServer/Messages/EntriesRequestMessage.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+using CommunityToolkit.Mvvm.Messaging.Messages;
+
+using DevServer.ViewModels;
+
+namespace DevServer.Messages;
+
+public class EntriesRequestMessage : AsyncRequestMessage<IList<EntryViewModel>>
+{
+}

--- a/DevServer/Messages/EntryChangedMessage.cs
+++ b/DevServer/Messages/EntryChangedMessage.cs
@@ -1,0 +1,13 @@
+using CommunityToolkit.Mvvm.Messaging.Messages;
+
+using DevServer.Models;
+using DevServer.ViewModels;
+
+namespace DevServer.Messages;
+
+public class EntryChangedMessage : ValueChangedMessage<EntryViewModel>
+{
+    public EntryChangedMessage(EntryViewModel value) : base(value)
+    {
+    }
+}

--- a/DevServer/ViewModels/EntryListViewModel.cs
+++ b/DevServer/ViewModels/EntryListViewModel.cs
@@ -22,9 +22,6 @@ public partial class EntryListViewModel : RecipientViewModelBase
     [ObservableProperty]
     private EntryViewModel? _selectedEntry;
 
-    [ObservableProperty]
-    private bool _isEnabled = true;
-
     public EntryListViewModel()
     {
         IsActive = true;
@@ -32,11 +29,6 @@ public partial class EntryListViewModel : RecipientViewModelBase
 
     protected override void OnActivated()
     {
-        Messenger.Register<EntryListViewModel, ProcessRunningMessage>(
-            this,
-            (r, m) =>
-                r.IsEnabled = !m.Value);
-
         Messenger.Register<EntryListViewModel, EntryChangedMessage>(
             this,
             (r, m) =>

--- a/DevServer/ViewModels/EntryListViewModel.cs
+++ b/DevServer/ViewModels/EntryListViewModel.cs
@@ -44,6 +44,11 @@ public partial class EntryListViewModel : RecipientViewModelBase
             this,
             (r, m) =>
                 r.IsEnabled = !m.Value);
+
+        Messenger.Register<EntryListViewModel, EntryChangedMessage>(
+            this,
+            (r, m) =>
+                r.Entries.Remove(m.Value));
     }
 
     [RelayCommand]
@@ -83,23 +88,5 @@ public partial class EntryListViewModel : RecipientViewModelBase
     private Task AddEntry()
     {
         return Task.CompletedTask;
-    }
-
-    [RelayCommand]
-    private Task EditEntry()
-    {
-        return Task.CompletedTask;
-    }
-
-    [RelayCommand]
-    private async Task DeleteEntry()
-    {
-        if (_selectedEntry is null)
-        {
-            return;
-        }
-
-        await _entryService.DeleteEntry(_selectedEntry.FilePath);
-        _entries.Remove(_selectedEntry);
     }
 }

--- a/DevServer/ViewModels/EntryViewModel.cs
+++ b/DevServer/ViewModels/EntryViewModel.cs
@@ -29,7 +29,6 @@ public partial class EntryViewModel : RecipientViewModelBase
     [ObservableProperty]
     private Bitmap? _logo;
 
-
     public string FilePath => _entry.FilePath;
     public string Name => _entry.Name;
     public string? Description => _entry.Description;
@@ -37,7 +36,6 @@ public partial class EntryViewModel : RecipientViewModelBase
     public EntryViewModel(Entry entry)
     {
         _entry = entry;
-
 
         _logger = Ioc.Default.GetRequiredService<ILogger<EntryViewModel>>();
         _configurationManager = Ioc.Default.GetRequiredService<IConfigurationManager>();

--- a/DevServer/ViewModels/MainPanelViewModel.cs
+++ b/DevServer/ViewModels/MainPanelViewModel.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+
+using DevServer.Messages;
+using DevServer.Services;
+
+using Microsoft.Extensions.Logging;
+
+namespace DevServer.ViewModels;
+
+public partial class MainPanelViewModel : RecipientViewModelBase
+{
+    private readonly ILogger<MainPanelViewModel> _logger;
+    private readonly IEntryService _entryService;
+
+    public MainPanelViewModel(ILogger<MainPanelViewModel> logger,
+                              IEntryService entryService)
+    {
+        _logger = logger;
+        _entryService = entryService;
+
+        IsActive = true;
+    }
+
+    protected override void OnActivated()
+    {
+        Messenger.Register<MainPanelViewModel, EntriesRequestMessage>(this,
+                                                                      (r, m) =>
+                                                                          m.Reply(r.GetEntryList()));
+    }
+
+    [RelayCommand]
+    private Task DirectConnect()
+    {
+        return Task.CompletedTask;
+    }
+
+    [RelayCommand]
+    private Task AddEntry()
+    {
+        return Task.CompletedTask;
+    }
+
+    [RelayCommand]
+    private async Task RefreshEntries()
+    {
+        var entries = await GetEntryList();
+        Messenger.Send(new EntriesChangedMessage(entries));
+    }
+
+    private async Task<IList<EntryViewModel>> GetEntryList()
+    {
+        List<EntryViewModel> entries = new();
+
+        var enumerable = _entryService.GetEntries();
+        await using var enumerator = enumerable.GetAsyncEnumerator();
+        for (var more = true; more;)
+        {
+            try
+            {
+                more = await enumerator.MoveNextAsync();
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Could not parse entry");
+                continue;
+            }
+
+            if (more is not false)
+            {
+                // ensure we're not adding an extra entry if failed
+                entries.Add(new EntryViewModel(enumerator.Current));
+            }
+        }
+
+        return entries;
+    }
+}

--- a/DevServer/ViewModels/MainWindowViewModel.cs
+++ b/DevServer/ViewModels/MainWindowViewModel.cs
@@ -10,6 +10,9 @@ namespace DevServer.ViewModels;
 public partial class MainWindowViewModel : RecipientViewModelBase
 {
     [ObservableProperty]
+    private bool _canExecute;
+
+    [ObservableProperty]
     private WindowState _windowState;
 
     public EntryListViewModel EntryListViewModel { get; }
@@ -28,6 +31,11 @@ public partial class MainWindowViewModel : RecipientViewModelBase
         Messenger.Register<MainWindowViewModel, ProcessRunningMessage>(
             this,
             (r, m) =>
-                r.WindowState = m.Value ? WindowState.Minimized : WindowState.Normal);
+            {
+                // can execute if process is not running
+                r.CanExecute = !m.Value;
+
+                r.WindowState = m.Value ? WindowState.Minimized : WindowState.Normal;
+            });
     }
 }

--- a/DevServer/ViewModels/MainWindowViewModel.cs
+++ b/DevServer/ViewModels/MainWindowViewModel.cs
@@ -13,10 +13,12 @@ public partial class MainWindowViewModel : RecipientViewModelBase
     private WindowState _windowState;
 
     public EntryListViewModel EntryListViewModel { get; }
+    public MainPanelViewModel MainPanelViewModel { get; }
 
-    public MainWindowViewModel(EntryListViewModel entryListViewModel)
+    public MainWindowViewModel(EntryListViewModel entryListViewModel, MainPanelViewModel mainPanelViewModel)
     {
         EntryListViewModel = entryListViewModel;
+        MainPanelViewModel = mainPanelViewModel;
 
         IsActive = true;
     }

--- a/DevServer/Views/EntryListView.axaml
+++ b/DevServer/Views/EntryListView.axaml
@@ -45,12 +45,7 @@
             <Button Grid.Column="2" ToolTip.Tip="Add Server" Command="{Binding AddEntryCommand}">
                 <material:MaterialIcon Kind="Add" />
             </Button>
-            <Button Grid.Column="4" ToolTip.Tip="Delete Server" Command="{Binding DeleteEntryCommand}">
-                <material:MaterialIcon Kind="Minus" />
-            </Button>
-            <Button Grid.Column="5" ToolTip.Tip="Edit Server" Command="{Binding EditEntryCommand}">
-                <material:MaterialIcon Kind="EditOutline" />
-            </Button>
+
             <Button Grid.Column="6" ToolTip.Tip="Refresh Servers" Command="{Binding UpdateEntriesCommand}">
                 <material:MaterialIcon Kind="Refresh" />
             </Button>

--- a/DevServer/Views/EntryListView.axaml
+++ b/DevServer/Views/EntryListView.axaml
@@ -2,7 +2,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:material="using:Material.Icons.Avalonia"
              xmlns:local="clr-namespace:DevServer"
              xmlns:views="clr-namespace:DevServer.Views"
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
@@ -13,11 +12,11 @@
 
     <i:Interaction.Behaviors>
         <ia:EventTriggerBehavior EventName="AttachedToVisualTree">
-            <ia:InvokeCommandAction Command="{Binding UpdateEntriesCommand}" />
+            <ia:InvokeCommandAction Command="{Binding LoadEntriesCommand}" />
         </ia:EventTriggerBehavior>
     </i:Interaction.Behaviors>
 
-    <Grid RowDefinitions="* Auto">
+    <Grid>
         <ListBox Grid.Row="0"
                  IsEnabled="{Binding IsEnabled}"
                  Items="{Binding Entries}"
@@ -29,35 +28,6 @@
                 </DataTemplate>
             </ListBox.ItemTemplate>
         </ListBox>
-
-        <Grid Grid.Row="1"
-              IsEnabled="{Binding IsEnabled}"
-              ColumnDefinitions="Auto * Auto Auto Auto Auto Auto">
-            <Button Grid.Column="0" Command="{Binding DirectConnectCommand}">
-                <StackPanel Orientation="Horizontal">
-                    <material:MaterialIcon Kind="PlayNetwork" />
-                    <Separator Width="10" />
-                    <TextBlock Text="Direct Connect"
-                               FontWeight="Medium"
-                               VerticalAlignment="Center" />
-                </StackPanel>
-            </Button>
-            <Button Grid.Column="2" ToolTip.Tip="Add Server" Command="{Binding AddEntryCommand}">
-                <material:MaterialIcon Kind="Add" />
-            </Button>
-
-            <Button Grid.Column="6" ToolTip.Tip="Refresh Servers" Command="{Binding UpdateEntriesCommand}">
-                <material:MaterialIcon Kind="Refresh" />
-            </Button>
-
-            <Grid.Styles>
-                <Style Selector="material|MaterialIcon">
-                    <Setter Property="Width" Value="24" />
-                    <Setter Property="Height" Value="24" />
-                </Style>
-            </Grid.Styles>
-        </Grid>
     </Grid>
-
 
 </UserControl>

--- a/DevServer/Views/EntryListView.axaml
+++ b/DevServer/Views/EntryListView.axaml
@@ -5,8 +5,8 @@
              xmlns:material="using:Material.Icons.Avalonia"
              xmlns:local="clr-namespace:DevServer"
              xmlns:views="clr-namespace:DevServer.Views"
-             xmlns:i="using:Avalonia.Xaml.Interactivity"
-             xmlns:ia="using:Avalonia.Xaml.Interactions.Core"
+             xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
+             xmlns:ia="clr-namespace:Avalonia.Xaml.Interactions.Core;assembly=Avalonia.Xaml.Interactions"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="DevServer.Views.EntryListView"
              d:DataContext="{x:Static local:DesignData.EntryListViewModel}">

--- a/DevServer/Views/EntryView.axaml
+++ b/DevServer/Views/EntryView.axaml
@@ -33,8 +33,9 @@
             <Button ToolTip.Tip="Edit Server" Command="{Binding EditEntryCommand}">
                 <material:MaterialIcon Kind="Edit" />
             </Button>
+            <Separator Width="2" />
             <Button ToolTip.Tip="Delete Server" Command="{Binding DeleteEntryCommand}">
-                <material:MaterialIcon Kind="Remove" />
+                <material:MaterialIcon Kind="RemoveBold" />
             </Button>
         </DockPanel>
     </Grid>

--- a/DevServer/Views/EntryView.axaml
+++ b/DevServer/Views/EntryView.axaml
@@ -4,8 +4,8 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:material="using:Material.Icons.Avalonia"
              xmlns:local="clr-namespace:DevServer"
-             xmlns:i="using:Avalonia.Xaml.Interactivity"
-             xmlns:ia="using:Avalonia.Xaml.Interactions.Core"
+             xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
+             xmlns:ia="clr-namespace:Avalonia.Xaml.Interactions.Core;assembly=Avalonia.Xaml.Interactions"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="100"
              x:Class="DevServer.Views.EntryView"
              d:DataContext="{x:Static local:DesignData.EntryViewModel}">

--- a/DevServer/Views/EntryView.axaml
+++ b/DevServer/Views/EntryView.axaml
@@ -26,8 +26,15 @@
             <TextBlock Text="{Binding Description}" FontSize="12" Margin="0 2 0 0" />
         </DockPanel>
         <DockPanel Grid.Column="2">
-            <Button Command="{Binding PlayCommand}">
+            <Button ToolTip.Tip="Play Server" Command="{Binding PlayCommand}">
                 <material:MaterialIcon Kind="Play" />
+            </Button>
+            <Separator Width="2" />
+            <Button ToolTip.Tip="Edit Server" Command="{Binding EditEntryCommand}">
+                <material:MaterialIcon Kind="Edit" />
+            </Button>
+            <Button ToolTip.Tip="Delete Server" Command="{Binding DeleteEntryCommand}">
+                <material:MaterialIcon Kind="Remove" />
             </Button>
         </DockPanel>
     </Grid>

--- a/DevServer/Views/MainPanelView.axaml
+++ b/DevServer/Views/MainPanelView.axaml
@@ -1,0 +1,41 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:material="using:Material.Icons.Avalonia"
+             xmlns:local="clr-namespace:DevServer"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="40"
+             x:Class="DevServer.Views.MainPanelView"
+             d:DataContext="{x:Static local:DesignData.MainPanelViewModel}">
+
+    <Grid
+        IsEnabled="{Binding IsEnabled}"
+        ColumnDefinitions="Auto * Auto Auto">
+
+        <Button Grid.Column="0" Command="{Binding DirectConnectCommand}">
+            <StackPanel Orientation="Horizontal">
+                <material:MaterialIcon Kind="PlayNetwork" />
+                <Separator Width="10" />
+                <TextBlock Text="Direct Connect"
+                           FontWeight="Medium"
+                           VerticalAlignment="Center" />
+            </StackPanel>
+        </Button>
+
+        <Button Grid.Column="2" ToolTip.Tip="Add Server" Command="{Binding AddEntryCommand}">
+            <material:MaterialIcon Kind="Add" />
+        </Button>
+
+        <Button Grid.Column="3" ToolTip.Tip="Refresh Servers" Command="{Binding RefreshEntriesCommand}">
+            <material:MaterialIcon Kind="Refresh" />
+        </Button>
+
+        <Grid.Styles>
+            <Style Selector="material|MaterialIcon">
+                <Setter Property="Width" Value="24" />
+                <Setter Property="Height" Value="24" />
+            </Style>
+        </Grid.Styles>
+    </Grid>
+
+</UserControl>

--- a/DevServer/Views/MainPanelView.axaml.cs
+++ b/DevServer/Views/MainPanelView.axaml.cs
@@ -1,0 +1,19 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace DevServer.Views;
+
+public partial class MainPanelView : UserControl
+{
+    public MainPanelView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}
+

--- a/DevServer/Views/MainWindow.axaml
+++ b/DevServer/Views/MainWindow.axaml
@@ -11,7 +11,8 @@
         WindowState="{Binding WindowState}"
         d:DataContext="{x:Static local:DesignData.MainWindowViewModel}">
 
-    <Grid>
-        <v:EntryListView DataContext="{Binding EntryListViewModel}" />
+    <Grid RowDefinitions="* Auto">
+        <v:EntryListView Grid.Row="0" DataContext="{Binding EntryListViewModel}" />
+        <v:MainPanelView Grid.Row="1" DataContext="{Binding MainPanelViewModel}" />
     </Grid>
 </Window>


### PR DESCRIPTION
Each added entry has a delete and edit button. Panel with buttons now has its own view. All entry loading logic now in MainPanelViewModel. EntryViewModel now requests entries from MainPanelViewModel on launch.